### PR TITLE
bugfix database connection memory leak

### DIFF
--- a/src/main/java/account_update/email_update/NeonUpdateEmailActionTokenHandler.java
+++ b/src/main/java/account_update/email_update/NeonUpdateEmailActionTokenHandler.java
@@ -142,7 +142,7 @@ public class NeonUpdateEmailActionTokenHandler extends AbstractActionTokenHandle
                 "BEGIN;" +
                 "UPDATE auth_accounts SET email = ? WHERE provider_uid = ?;" +
                 "UPDATE users SET email = ? WHERE id::text = ?;" +
-                "END"
+                "END;"
             )) {
                 stmt.setString(1, newEmail);
                 stmt.setString(2, user.getId());


### PR DESCRIPTION
- move connection creation to method local
- wrap connection in try-with-resources to clean up after method
- reformat some multi-line args and method chains
- use try-with-resources where suggested automatically by IntelliJ

see also https://github.com/neondatabase/cloud/pull/10765