### PR TITLE
remove explicit close for keycloak resources

### DIFF
--- a/src/main/java/account_update/email_update/NeonUpdateEmailActionTokenHandler.java
+++ b/src/main/java/account_update/email_update/NeonUpdateEmailActionTokenHandler.java
@@ -104,8 +104,8 @@ public class NeonUpdateEmailActionTokenHandler extends AbstractActionTokenHandle
             throw new RuntimeException("ERROR updating console database after email change for keycloak user " + user.getId(), e);
         }
 
-        return forms.setAttribute("messageHeader", forms.getMessage("emailUpdatedTitle")).
-            setSuccess("emailUpdated", newEmail)
+        return forms.setAttribute("messageHeader", forms.getMessage("emailUpdatedTitle"))
+            .setSuccess("emailUpdated", newEmail)
             .createInfoPage();
     }
 


### PR DESCRIPTION
Keycloak provides many session and provider resources which implement a `close` method or the `AutoCloseable` interface. However from documentation and studying other usages of these resources, it appears that we should not call `close` on these methods ourselves, and instead allow keycloak to manage them instead

This is motivated by an often repeated documentation comment I found in the `KeycloakSession` type for some methods we use:

> Returns a managed provider instance. **Will start a provider transaction.** 
> **This transaction is managed by the KeycloakSession transaction.**
> Returns:
>
> Throws:
> IllegalStateException – if transaction is not active

The highlighted text, along with studying the other usages of these methods in similar token handler classes, leads me to believe we should not be calling these methods directly

This _may_ provide a resolution to the ongoing memory leak problem, as it may be the case that closing these resources too early prevents keycloak from releasing them properly when it finally needs to