### PR TITLE
update org.postgresql:postgresql@42.7.0 to 42.7.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <keycloak.version>22.0.3</keycloak.version>
-    <postgres.version>42.7.0</postgres.version>
+    <postgres.version>42.7.3</postgres.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
The current version is vulnerable to CVE-2024-1597 (Sql injection)

Please see the vulnerability details below:

> pgjdbc, the PostgreSQL JDBC Driver, allows attacker to inject SQL if using PreferQueryMode=SIMPLE. Note this is not the default. In the default mode there is no vulnerability. A placeholder for a numeric value must be immediately preceded by a minus. There must be a second placeholder for a string value after the first placeholder; both must be on the same line. By constructing a matching string payload, the attacker can inject SQL to alter the query,bypassing the protections that parameterized queries bring against SQL Injection attacks. Versions before 42.7.2, 42.6.1, 42.5.5, 42.4.4, 42.3.9, and 42.2.8 are affected.

Fix: Upgrade org.postgresql:postgresql@42.7.0 to 42.7.3.



