### PR TITLE
Save Vercel installation ID for future use

### DIFF
--- a/src/main/java/vercel/VercelMPIdentityProvider.java
+++ b/src/main/java/vercel/VercelMPIdentityProvider.java
@@ -2,7 +2,6 @@ package vercel;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
@@ -41,6 +40,8 @@ import java.util.Objects;
 
 public class VercelMPIdentityProvider extends OIDCIdentityProvider implements SocialIdentityProvider<OIDCIdentityProviderConfig> {
     private static final String BROKER_NONCE_PARAM = "BROKER_NONCE";
+    private static final String INSTALLATION_ID_ATTR = "vercel_installation_id";
+    private static final String INSTALLATION_ID_CLAIM = "installation_id";
 
     private static final Logger logger = Logger.getLogger(VercelMPIdentityProvider.class);
     //private static final String AUTH_URL = "https://api.vercel.com/oauth/authorize";
@@ -173,6 +174,7 @@ public class VercelMPIdentityProvider extends OIDCIdentityProvider implements So
         identity.setEmail(email);
         identity.setName(name);
         identity.setUsername((name == null || name.isEmpty()) ? email : name);
+        identity.setUserAttribute(INSTALLATION_ID_ATTR, (String) idToken.getOtherClaims().get(INSTALLATION_ID_CLAIM));
 
         identity.setBrokerUserId(getConfig().getAlias() + "." + id);
 
@@ -193,8 +195,6 @@ public class VercelMPIdentityProvider extends OIDCIdentityProvider implements So
             this.provider = provider;
         }
 
-        // Override parent's authResponse and change annotation to @POST to be able to use @GET with another list of parameters
-        // and we need to initialize `authSession` properly.
         @GET
         @Override
         public Response authResponse(@QueryParam(AbstractOAuth2IdentityProvider.OAUTH2_PARAMETER_STATE) String state,

--- a/src/main/java/vercel/VercelMPIdentityProvider.java
+++ b/src/main/java/vercel/VercelMPIdentityProvider.java
@@ -40,8 +40,6 @@ import java.util.Objects;
 
 public class VercelMPIdentityProvider extends OIDCIdentityProvider implements SocialIdentityProvider<OIDCIdentityProviderConfig> {
     private static final String BROKER_NONCE_PARAM = "BROKER_NONCE";
-    private static final String INSTALLATION_ID_ATTR = "vercel_installation_id";
-    private static final String INSTALLATION_ID_CLAIM = "installation_id";
 
     private static final Logger logger = Logger.getLogger(VercelMPIdentityProvider.class);
     //private static final String AUTH_URL = "https://api.vercel.com/oauth/authorize";

--- a/src/main/java/vercel/VercelMPIdentityProvider.java
+++ b/src/main/java/vercel/VercelMPIdentityProvider.java
@@ -174,7 +174,6 @@ public class VercelMPIdentityProvider extends OIDCIdentityProvider implements So
         identity.setEmail(email);
         identity.setName(name);
         identity.setUsername((name == null || name.isEmpty()) ? email : name);
-        identity.setUserAttribute(INSTALLATION_ID_ATTR, (String) idToken.getOtherClaims().get(INSTALLATION_ID_CLAIM));
 
         identity.setBrokerUserId(getConfig().getAlias() + "." + id);
 

--- a/src/main/java/vercel/VercelMPUserAttributeMapper.java
+++ b/src/main/java/vercel/VercelMPUserAttributeMapper.java
@@ -1,0 +1,23 @@
+package vercel;
+
+import org.keycloak.broker.oidc.mappers.UserAttributeMapper;
+
+/**
+ * User attribute mapper.
+ *
+ */
+public class VercelMPUserAttributeMapper extends UserAttributeMapper {
+
+	private static final String[] cp = new String[] { VercelMPIdentityProviderFactory.PROVIDER_ID };
+
+	@Override
+	public String[] getCompatibleProviders() {
+		return cp;
+	}
+
+	@Override
+	public String getId() {
+		return "vercelmp-user-attribute-mapper";
+	}
+
+}

--- a/src/main/resources/META-INF/services/org.keycloak.broker.provider.IdentityProviderMapper
+++ b/src/main/resources/META-INF/services/org.keycloak.broker.provider.IdentityProviderMapper
@@ -1,0 +1,1 @@
+vercel.VercelMPUserAttributeMapper


### PR DESCRIPTION
We will need this ID to link a user to an organization, managed by Vercel marketplace.

Unfortunately, we need such a hack, because Vercel doesn't provide an authorization endpoint to fetch all the user's teams at Vercel.